### PR TITLE
Remove Killian Muldoon as maintainer on repos

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -43,7 +43,6 @@
 
 * Abdul Halim (Intel)
 * Martin Kennelly (Red Hat)
-* Killian Muldoon (Intel)
 * Zenghui Shi (Red Hat)
 * Peng Liu (Red Hat)
 * Adrian Chiris (Nvidia)
@@ -53,7 +52,6 @@
 
 * Abdul Halim (Intel)
 * Martin Kennelly (Red Hat)
-* Killian Muldoon (Intel)
 * Zenghui Shi (Red Hat)
 * Peng Liu (Red Hat)
 * Adrian Chiris (Nvidia)
@@ -70,6 +68,5 @@
 
 * Abdul Halim (Intel)
 * Martin Kennelly (Red Hat)
-* Killian Muldoon (Intel)
 * Zenghui Shi (Red Hat)
 * Peng Liu (Red Hat)

--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -2,7 +2,6 @@
 
 * Doug Smith (Red Hat)
 * Tomofumi Hayashi (Red Hat)
-* Killian Muldoon (Intel)
 * Adrian Chiris (Nvidia)
 * Martin Kennelly (Red Hat)
 * Billy McFall (Red Hat)


### PR DESCRIPTION
Signed-off-by: killianmuldoon <kmuldoon@vmware.com>

Remove Killian Muldoon as maintainer across Network Plumbing Working Group repos.